### PR TITLE
Fix POD after module rename

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/CheckChanges.pm
+++ b/lib/Dist/Zilla/Plugin/Test/CheckChanges.pm
@@ -20,7 +20,7 @@ __END__
 
 In C<dist.ini>:
 
-    [CheckChangesTests]
+    [Test::CheckChanges]
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
The POD was still refering to `[CheckChangesTests]` instead of the new name. This patch fixes that.
